### PR TITLE
fix: robustly extract JSON from LLM response content

### DIFF
--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -244,17 +244,17 @@ func (c *OllamaClient) extractOnce(ctx context.Context, text string, temperature
 
 	content := chatResp.Choices[0].Message.Content
 
-	// Strip markdown code fences if the model wraps JSON in ```json ... ```
-	if idx := strings.Index(content, "{"); idx > 0 {
-		content = content[idx:]
+	// Strip any preamble/markdown and extract the JSON object.
+	start := strings.Index(content, "{")
+	end := strings.LastIndex(content, "}")
+	if start == -1 || end == -1 || end < start {
+		return nil, fmt.Errorf("no JSON object in LLM response: %q", content)
 	}
-	if idx := strings.LastIndex(content, "}"); idx >= 0 && idx < len(content)-1 {
-		content = content[:idx+1]
-	}
+	content = content[start : end+1]
 
 	var result ExtractionResult
 	if err := json.Unmarshal([]byte(content), &result); err != nil {
-		return nil, fmt.Errorf("parse extraction JSON: %w", err)
+		return nil, fmt.Errorf("parse extraction JSON: %w (raw: %q)", err, content)
 	}
 
 	return &result, nil


### PR DESCRIPTION
## Summary
- Replace broken preamble-stripping logic (`idx > 0` missed `idx == -1` case) with a clean first-`{` to last-`}` slice
- Surface raw LLM response content in the error message for easier debugging

## Root cause
When the model returned a response with no `{` at all (e.g. starting with `"Processing..."`), `strings.Index` returned `-1` and the old code passed the raw non-JSON string straight to `json.Unmarshal`, producing the `invalid character 'P'` error.

## Test plan
- [ ] Trigger enrichment on a listing that previously failed with `invalid character` — should now return a clear error with the raw response logged
- [ ] Happy path enrichment still works